### PR TITLE
Fix get cded dem res

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,8 @@ Imports:
     stringr,
     bcmaps,
     rlang
+Remotes:
+    bcgov/bcmaps
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/R/get_cded_dem.R
+++ b/R/get_cded_dem.R
@@ -52,6 +52,11 @@ get_cded_dem <- function(aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates
 
   cded_raw <- bcmaps::cded_terra(aoi, ...)
 
+
+
+
+  aoi_rast <- create_template_raster(aoi, res = res, write_output = FALSE )
+
   cded <- terra::project(cded_raw, aoi)
 
   cded_res <- terra::res(cded)[1]

--- a/R/get_cded_dem.R
+++ b/R/get_cded_dem.R
@@ -22,7 +22,7 @@
 #' \dontrun{
 #' get_cded_dem(
 #'   aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates$path_abs, "25m", "template.tif"),
-#'   res = FALSE,
+#'   res = NULL,
 #'   out_dir = PEMprepr::read_fid()$dir_1020_covariates$path_abs,
 #'   write_output = TRUE,
 #'   overwrite = FALSE

--- a/R/get_cded_dem.R
+++ b/R/get_cded_dem.R
@@ -5,7 +5,7 @@
 #' create_raster_template().
 #'
 #' @param  aoi An `SpatRast` object or path to a spatial file (.tif) usually generated
-#'      when calling [create_base_raster()]. Should be a meter based coordinate reference system.
+#'      when calling [create_template_raster()]. Should be a meter based coordinate reference system.
 #' @param res resolution in meters of final project. If no values specified (default is FALSE),
 #'      output spatRast will match the resolution of aoi.
 #' @param write_output should the cded spatRast be written to disk?
@@ -53,8 +53,8 @@ get_cded_dem <- function(aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates
       )
 
       aoi_out <- aoi
-      res(aoi_out) = res
-      aoi_template <- resample(aoi, aoi_out)
+      terra::res(aoi_out) <- res
+      aoi_template <- terra::resample(aoi, aoi_out)
 
     } else {
 

--- a/R/get_cded_dem.R
+++ b/R/get_cded_dem.R
@@ -4,11 +4,12 @@
 #' Canadian Digital Elevation Data set to match the raster template built using
 #' create_raster_template().
 #'
-#' @param  aoi the `SpatRast` created using the create_base_raster() on which the
-#'      DEM data will be extracted, currently accepts raster (.tif) or filepath.
-#' @param res resolution in meters of final project
-#' @param write_output should the snapped aoi bounding box be written to disk?
-#'     If `TRUE` (default), will write to `out_dir`
+#' @param  aoi An `SpatRast` object or path to a spatial file (.tif) usually generated
+#'      when calling [create_base_raster()]. Should be a meter based coordinate reference system.
+#' @param res resolution in meters of final project. If no values specified (default is FALSE),
+#'      output spatRast will match the resolution of aoi.
+#' @param write_output should the cded spatRast be written to disk?
+#'     If `TRUE` (default), will write to `out_dir` in a subfolder defined by resolution e.g: "25m".
 #' @param out_dir  the root directory to hold the cded dem spatRast file. If not
 #'     specified uses the default from the `fid` folder structure.
 #' @inheritParams terra::writeRaster
@@ -19,18 +20,23 @@
 #'
 #' @examples
 #' \dontrun{
-#' get_cded_dem(aoi_bb = file.path(fid$shape_dir_1010[2],"aoi_snapped.gpkg"),
-#'     res = 5, out_dir = fid$cov_dir_1020[2]))
+#' get_cded_dem(
+#'   aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates$path_abs, "25m", "template.tif"),
+#'   res = FALSE,
+#'   out_dir = PEMprepr::read_fid()$dir_1020_covariates$path_abs,
+#'   write_output = TRUE
+#'   overwrite = FALSE)
 #' }
 get_cded_dem <- function(aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates$path_abs, "25m", "template.tif"),
                          res = FALSE,
                          out_dir = PEMprepr::read_fid()$dir_1020_covariates$path_abs,
                          write_output = TRUE,
                          overwrite = FALSE, ...) {
+
   if (inherits(aoi, c("character"))) {
     aoi <- terra::rast(aoi)
   } else if (!inherits(aoi, c("SpatRaster"))) {
-    cli::cli_abort("{.var aoi} must be an spatRast or a path to a .tif file")
+    cli::cli_abort("{.var aoi} must be a SpatRaster or a path to a file")
   }
 
   aoi_res <- terra::res(aoi)[1]
@@ -40,34 +46,44 @@ get_cded_dem <- function(aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates
       cli::cli_abort("{.var res} must be numeric")
     }
 
+    if(aoi_res != res) {
+
+      cli::cli_alert_warning(
+        "Updating cded to resolution specified"
+      )
+
+      aoi_out <- aoi
+      res(aoi_out) = res
+      aoi_template <- resample(aoi, aoi_out)
+
+    } else {
+
+      aoi_template <- aoi
+      cli::cli_alert_warning(
+        "Specified res matches template resolution, output cded resolution will be {.var res}"
+      )
+    }
+
     output_res <- res
+
   } else {
+
+    aoi_template <- aoi
     output_res <- aoi_res
     cli::cli_alert_warning(
-      "No spatial resolution specified, cded output resolution will match input raster"
+      "No spatial resolution specified, cded output spatial resolution will match input raster"
     )
   }
 
-  output_dir <- fs::path(out_dir, paste0(res, "m"))
+  cded_raw <- bcmaps::cded_terra(aoi_template, ...)
+  #cded_raw <- bcmaps::cded_terra(aoi_template)#, ...)
 
-  cded_raw <- bcmaps::cded_terra(aoi, ...)
+  cded <- terra::project(cded_raw, aoi_template)
 
-
-
-
-  aoi_rast <- create_template_raster(aoi, res = res, write_output = FALSE )
-
-  cded <- terra::project(cded_raw, aoi)
-
-  cded_res <- terra::res(cded)[1]
-
-  if(cded_res != output_res) {
-    cded <- terra::disagg(cded, cded_res/output_res)
-  }
-
-
-  ## check if folder exists
   if (write_output) {
+
+    output_dir <- fs::path(out_dir, paste0(output_res, "m"))
+
     if (!fs::dir_exists(fs::path(output_dir))) {
       fs::dir_create(fs::path(output_dir), recurse = TRUE)
     }

--- a/R/get_cded_dem.R
+++ b/R/get_cded_dem.R
@@ -6,7 +6,7 @@
 #'
 #' @param  aoi An `SpatRast` object or path to a spatial file (.tif) usually generated
 #'      when calling [create_template_raster()]. Should be a meter based coordinate reference system.
-#' @param res resolution in meters of final project. If no values specified (default is FALSE),
+#' @param res resolution in meters of final project. If no values specified (default is `NULL`),
 #'      output spatRast will match the resolution of aoi.
 #' @param write_output should the cded spatRast be written to disk?
 #'     If `TRUE` (default), will write to `out_dir` in a subfolder defined by resolution e.g: "25m".

--- a/R/get_cded_dem.R
+++ b/R/get_cded_dem.R
@@ -28,7 +28,7 @@
 #'   overwrite = FALSE)
 #' }
 get_cded_dem <- function(aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates$path_abs, "25m", "template.tif"),
-                         res = FALSE,
+                         res = NULL,
                          out_dir = PEMprepr::read_fid()$dir_1020_covariates$path_abs,
                          write_output = TRUE,
                          overwrite = FALSE, ...) {

--- a/R/get_cded_dem.R
+++ b/R/get_cded_dem.R
@@ -41,7 +41,7 @@ get_cded_dem <- function(aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates
 
   aoi_res <- terra::res(aoi)[1]
 
-  if(res) {
+  if (!is.null(res)) { 
     if (!is.numeric(res)) {
       cli::cli_abort("{.var res} must be numeric")
     }

--- a/R/get_cded_dem.R
+++ b/R/get_cded_dem.R
@@ -52,9 +52,7 @@ get_cded_dem <- function(
     output_res <- terra::res(aoi_template)[1]
     output_dir <- fs::path(out_dir, paste0(output_res, "m"))
 
-    if (!fs::dir_exists(fs::path(output_dir))) {
-      fs::dir_create(fs::path(output_dir), recurse = TRUE)
-    }
+    fs::dir_create(fs::path(output_dir), recurse = TRUE)
     terra::writeRaster(cded, fs::path(output_dir, "dem.tif"), overwrite = overwrite)
     cli::cat_line()
     cli::cli_alert_success(

--- a/man/get_cded_dem.Rd
+++ b/man/get_cded_dem.Rd
@@ -7,7 +7,7 @@
 get_cded_dem(
   aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates$path_abs, "25m",
     "template.tif"),
-  res = FALSE,
+  res = NULL,
   out_dir = PEMprepr::read_fid()$dir_1020_covariates$path_abs,
   write_output = TRUE,
   overwrite = FALSE,
@@ -18,7 +18,7 @@ get_cded_dem(
 \item{aoi}{An \code{SpatRast} object or path to a spatial file (.tif) usually generated
 when calling \code{\link[=create_template_raster]{create_template_raster()}}. Should be a meter based coordinate reference system.}
 
-\item{res}{resolution in meters of final project. If no values specified (default is FALSE),
+\item{res}{resolution in meters of final project. If no values specified (default is \code{NULL}),
 output spatRast will match the resolution of aoi.}
 
 \item{out_dir}{the root directory to hold the cded dem spatRast file. If not

--- a/man/get_cded_dem.Rd
+++ b/man/get_cded_dem.Rd
@@ -7,7 +7,7 @@
 get_cded_dem(
   aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates$path_abs, "25m",
     "template.tif"),
-  res = 5,
+  res = FALSE,
   out_dir = PEMprepr::read_fid()$dir_1020_covariates$path_abs,
   write_output = TRUE,
   overwrite = FALSE,
@@ -15,16 +15,17 @@ get_cded_dem(
 )
 }
 \arguments{
-\item{aoi}{the \code{SpatRast} created using the create_base_raster() on which the
-DEM data will be extracted, currently accepts raster (.tif) or filepath.}
+\item{aoi}{An \code{SpatRast} object or path to a spatial file (.tif) usually generated
+when calling \code{\link[=create_base_raster]{create_base_raster()}}. Should be a meter based coordinate reference system.}
 
-\item{res}{resolution in meters of final project}
+\item{res}{resolution in meters of final project. If no values specified (default is FALSE),
+output spatRast will match the resolution of aoi.}
 
 \item{out_dir}{the root directory to hold the cded dem spatRast file. If not
 specified uses the default from the \code{fid} folder structure.}
 
-\item{write_output}{should the snapped aoi bounding box be written to disk?
-If \code{TRUE} (default), will write to \code{out_dir}}
+\item{write_output}{should the cded spatRast be written to disk?
+If \code{TRUE} (default), will write to \code{out_dir} in a subfolder defined by resolution e.g: "25m".}
 
 \item{overwrite}{logical. If \code{TRUE}, \code{filename} is overwritten}
 
@@ -40,7 +41,11 @@ create_raster_template().
 }
 \examples{
 \dontrun{
-get_cded_dem(aoi_bb = file.path(fid$shape_dir_1010[2],"aoi_snapped.gpkg"),
-    res = 5, out_dir = fid$cov_dir_1020[2]))
+get_cded_dem(
+  aoi = fs::path(PEMprepr::read_fid()$dir_1020_covariates$path_abs, "25m", "template.tif"),
+  res = FALSE,
+  out_dir = PEMprepr::read_fid()$dir_1020_covariates$path_abs,
+  write_output = TRUE
+  overwrite = FALSE)
 }
 }

--- a/man/get_cded_dem.Rd
+++ b/man/get_cded_dem.Rd
@@ -16,7 +16,7 @@ get_cded_dem(
 }
 \arguments{
 \item{aoi}{An \code{SpatRast} object or path to a spatial file (.tif) usually generated
-when calling \code{\link[=create_base_raster]{create_base_raster()}}. Should be a meter based coordinate reference system.}
+when calling \code{\link[=create_template_raster]{create_template_raster()}}. Should be a meter based coordinate reference system.}
 
 \item{res}{resolution in meters of final project. If no values specified (default is FALSE),
 output spatRast will match the resolution of aoi.}

--- a/tests/testthat/test-get_cded_dem.R
+++ b/tests/testthat/test-get_cded_dem.R
@@ -57,7 +57,7 @@ test_that("get_cded_dem works with multiple input types", {
 
 })
 
-test_that("res works", {
+test_that("default res works", {
   skip_if_offline()
   skip_on_cran()
 
@@ -69,7 +69,6 @@ test_that("res works", {
 
   rast_cded <- get_cded_dem(
     aoi_rast,
-    res = 100,
     out_dir = outdir,
     write_output = FALSE,
     ask = FALSE

--- a/tests/testthat/test-get_cded_dem.R
+++ b/tests/testthat/test-get_cded_dem.R
@@ -19,7 +19,7 @@ test_that("get_cded_dem works with multiple input types", {
 
   aoi_snapped <- make_test_aoi(outdir)
 
-  aoi_rast <- create_template_raster(aoi_snapped, res = 50,out_dir = outdir)
+  aoi_rast <- create_template_raster(aoi_snapped, res = 50, out_dir = outdir)
 
   rast_cded <- get_cded_dem(
     aoi_rast,

--- a/tests/testthat/test-get_cded_dem.R
+++ b/tests/testthat/test-get_cded_dem.R
@@ -8,7 +8,7 @@ test_that("get_cded fails with invalid input", {
 
   aoi_rast <- create_template_raster(aoi_snapped, res = 50, out_dir = outdir)
 
-  expect_error(get_cded_dem(aoi = 1, res = 1))
+  expect_error(get_cded_dem(aoi = 1, res = FALSE))
   expect_error(get_cded_dem(aoi = aoi_rast, res = "number"))
 
 })


### PR DESCRIPTION
Hi @ateucher 
I reworked this function to allow output resolution to be controlled by default template or user defined output (param = res, as a numeric (in meters).

I might be missing something in the if else statements, as I converted default res to a TRUE /FALSE, for initial check but I think this may skip over the is.numeric() check. It is a bit cumbersome as is with series of if statements. 

Tests passing, but failing on internet download issue as discussed. 

This should closes #15.  

Thanks