### PR TITLE
Speed up tests

### DIFF
--- a/tests/testthat/_snaps/create_base_vectors.md
+++ b/tests/testthat/_snaps/create_base_vectors.md
@@ -6,18 +6,7 @@
       Error in `snap_aoi()`:
       ! `aoi` must be an sf or an sfc object or a path to a file
 
-# create_base_vectors works with sf object
-
-    Code
-      fs::path_file(fs::dir_ls(outdir))
-    Output
-       [1] "bec.gpkg"            "cutblocks.gpkg"      "cutblocks_ften.gpkg"
-       [4] "fire.gpkg"           "ften.gpkg"           "major_towns_bc.gpkg"
-       [7] "road_network.gpkg"   "snap"                "vri.gpkg"           
-      [10] "vri_class1_2.gpkg"   "vri_class3.gpkg"     "vri_decid.gpkg"     
-      [13] "water.gpkg"         
-
-# create_base_vectors works with file
+# create_base_vectors works with sf and/or path to file
 
     Code
       fs::path_file(fs::dir_ls(outdir))

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,6 +1,12 @@
-# Set a directory for bcmaps cded cache so they can be reused across tests
-cache_path <- fs::path(tempdir(), "bcmaps_cache")
-opts <- options("bcmaps.data_dir" = cache_path)
+# Set a directory for bcmaps cded cache on GitHub actions so they can be reused
+# across tests, otherwise each test is osolated and they are downloaded each
+# time. Use default cache location when running locally so cached files persist
+# across test runs
+on_ci <- isTRUE(as.logical(Sys.getenv("CI", "false")))
+if (on_ci) {
+  cache_path <- fs::path(tempdir(), "bcmaps_cache")
+  opts <- options("bcmaps.data_dir" = cache_path)
 
-withr::defer(options(opts), teardown_env())
-withr::defer(unlink(cache_path, recursive = TRUE), teardown_env())
+  withr::defer(options(opts), teardown_env())
+  withr::defer(unlink(cache_path, recursive = TRUE), teardown_env())
+}

--- a/tests/testthat/test-create_base_vectors.R
+++ b/tests/testthat/test-create_base_vectors.R
@@ -7,7 +7,7 @@ test_that("create_base_vectors fails with invalid input", {
   )
 })
 
-test_that("create_base_vectors works with sf object", {
+test_that("create_base_vectors works with sf and/or path to file", {
   skip_if_offline()
   skip_on_cran()
 
@@ -15,25 +15,19 @@ test_that("create_base_vectors works with sf object", {
 
   aoi_snapped <- make_test_aoi(outdir)
 
-  out <- create_base_vectors(
-    aoi_snapped,
-    out_dir = outdir
+  # Randomly select sf or character method to test, so we only run the whole
+  # function once - it is a lot of bcdata calls!
+  which_method <- sample(c("sf", "character"), size = 1)
+  input <- switch(
+    which_method,
+    "sf" = aoi_snapped,
+    "character" = fs::path(outdir, "snap", "aoi_snapped.gpkg")
   )
 
-  expect_equal(outdir, out)
-  expect_snapshot(fs::path_file(fs::dir_ls(outdir)))
-})
-
-test_that("create_base_vectors works with file", {
-  skip_if_offline()
-  skip_on_cran()
-
-  outdir <- withr::local_tempdir()
-
-  aoi_snapped <- make_test_aoi(outdir)
+  message("Testing ", which_method, " method of `create_base_vectors()")
 
   out <- create_base_vectors(
-    fs::path(outdir, "snap", "aoi_snapped.gpkg"),
+    input,
     out_dir = outdir
   )
 

--- a/tests/testthat/test-create_base_vectors.R
+++ b/tests/testthat/test-create_base_vectors.R
@@ -18,8 +18,7 @@ test_that("create_base_vectors works with sf and/or path to file", {
   # Randomly select sf or character method to test, so we only run the whole
   # function once - it is a lot of bcdata calls!
   which_method <- sample(c("sf", "character"), size = 1)
-  input <- switch(
-    which_method,
+  input <- switch(which_method,
     "sf" = aoi_snapped,
     "character" = fs::path(outdir, "snap", "aoi_snapped.gpkg")
   )


### PR DESCRIPTION
- Use global bcmaps cache locally: Set cache temporarily on CI, but use global cache when running locally so that we don't have to re-download cded files each time we run...
- Randomly select `create_base_vectors()` method to test - either `sf` or `character` - they both do the same thing, snapshot will be consistent

Closes #18 